### PR TITLE
Deduplicate code in cModule::findSubmodule by calling getSubmodule

### DIFF
--- a/src/sim/cmodule.cc
+++ b/src/sim/cmodule.cc
@@ -1046,13 +1046,14 @@ bool cModule::checkInternalConnections() const
 
 int cModule::findSubmodule(const char *name, int index) const
 {
-    for (SubmoduleIterator it(this); !it.end(); ++it) {
-        cModule *submodule = *it;
-        if (submodule->isName(name) && ((index == -1 && !submodule->isVector()) || submodule->getIndex() == index))
-            return submodule->getId();
+    int result = -1;
+    cModule *submodule = getSubmodule(name, index);
+
+    if (submodule) {
+        result = submodule->getId();
     }
 
-    return -1;
+    return result;
 }
 
 cModule *cModule::getSubmodule(const char *name, int index) const


### PR DESCRIPTION
Hi,

while browsing through the OMNet-Code, I discovered that that findSubmodule and the getSubmodule within the cModule-class almost contain the same code. I thus changed findSubmodule so that it calls getSubmodule instead.

I tried to run the OMNet test suite to check if this change breaks anything. However, I were not able to run them as the call to "make tests" always failed with the message

"OsgAnimator.cc:18:21: fatal error: osg/Group: No such file or directory"