### PR TITLE
Fix memory access error in cXMLElement::addAttr

### DIFF
--- a/src/sim/cxmlelement.cc
+++ b/src/sim/cxmlelement.cc
@@ -156,7 +156,7 @@ const char **cXMLElement::addAttr(const char *attr)
     const char **newAttrs = new const char *[2*numAttrs+2+1];
     for (int i = 0; i < 2*numAttrs; i++)
         newAttrs[i] = attrs[i];
-    const char **newAttr = attrs + 2*numAttrs;
+    const char **newAttr = newAttrs + 2*numAttrs;
     newAttr[0] = getPooledName(attr);
     newAttr[1] = nullptr; // value
     newAttr[2] = nullptr; // end marker


### PR DESCRIPTION
Commit 5c312df920928e8f92ca26f1ebe5c0257f5780f8 might have introduce a memory access error when calling `cXMLElement::addAttr` (via `cXMLElement::setAttribute`). The proposed patch seems to stop this from happening.