### PR TITLE
SelectionStrategies isSelectable improved when used for output

### DIFF
--- a/samples/queueinglib/SelectionStrategies.cc
+++ b/samples/queueinglib/SelectionStrategies.cc
@@ -59,7 +59,10 @@ bool SelectionStrategy::isSelectable(cModule *module)
 {
     IPassiveQueue *pqueue = dynamic_cast<IPassiveQueue *>(module);
     if (pqueue != nullptr)
-        return pqueue->length() > 0;
+        if (isInputGate)
+            return pqueue->length() > 0;
+        else
+            return true;
 
     IServer *server = dynamic_cast<IServer *>(module);
     if (server != nullptr)
@@ -178,4 +181,3 @@ int LongestQueueSelectionStrategy::select()
 }
 
 }; //namespace
-


### PR DESCRIPTION
When the output of a SelectionStrategy is a Queue it is always Selectable (it can still cause drop, but it must be controlled at an higher level)