### PR TITLE
Colon not allowed in windows paths

### DIFF
--- a/src/common/stringutil.cc
+++ b/src/common/stringutil.cc
@@ -897,7 +897,7 @@ std::string opp_makedatetimestring()
     time_t t = time(nullptr);
     struct tm tm = *localtime(&t);
     char timestr[32];
-    sprintf(timestr, "%04d%02d%02d-%02d:%02d:%02d",
+    sprintf(timestr, "%04d%02d%02d-%02d%02d%02d",
             1900+tm.tm_year, tm.tm_mon+1, tm.tm_mday,
             tm.tm_hour, tm.tm_min, tm.tm_sec);
     return timestr;

--- a/src/common/stringutil.h
+++ b/src/common/stringutil.h
@@ -434,7 +434,7 @@ COMMON_API double opp_atof(const char *s);
 COMMON_API std::string opp_formatdouble(double value, int numSignificantDigits);
 
 /**
- * Returns the current date/time as a string in the "yyyymmdd-hh:mm:ss" format.
+ * Returns the current date/time as a string in the "yyyymmdd-hhmmss" format.
  */
 COMMON_API std::string opp_makedatetimestring();
 


### PR DESCRIPTION
For our experiments, the results are stored in the following format:

`result-dir = results/`
`output-vector-file = "${resultdir}/${datetime}_${inifile}-${configname}-${runnumber}.vec"`

The default format of `${datetime}` includes colons (`:`) which can not be used for filenames on Windows (besides others: `< > ? " | \ / *`).

This PR changes the output of `${datetime}` from `yyyymmdd-hh:mm:ss` to `yyyymmdd-hhmmss`.