### PR TITLE
Fix integer overflow in SimTime

### DIFF
--- a/src/sim/simtime.cc
+++ b/src/sim/simtime.cc
@@ -45,7 +45,10 @@ static void fillPowersOfTen()
     int64_t power = 1;
     for (int i = 0; i <= MAX_POWER_OF_TEN; i++) {
         powersOfTen[i] = power;
-        power *= 10;
+        // prevent signed integer overflow
+        if (i < MAX_POWER_OF_TEN) {
+            power *= 10;
+        }
     }
 }
 


### PR DESCRIPTION
Compiling & running with UBSan produces the following error:
```
simtime.cc:48:15: runtime error: signed integer overflow: 1000000000000000000 * 10 cannot be represented in type 'long'
```

The overflow happens because the multiplication to generate the next power of 10 happens unconditionally.

Fix this by checking if the next power of 10 is actually needed before executing the multiplication.