### PR TITLE
Check for `nullptr` in argument passed to `memcpy` in cSimulation

### DIFF
--- a/src/sim/csimulation.cc
+++ b/src/sim/csimulation.cc
@@ -316,7 +316,10 @@ int cSimulation::registerComponent(cComponent *component)
     if (lastComponentId >= size) {
         // vector full, grow by delta
         cComponent **v = new cComponent *[size + delta];
-        memcpy(v, componentv, sizeof(cComponent *) * size);
+        // source for memcpy can't be nullptr
+        if (componentv) {
+            memcpy(v, componentv, sizeof(cComponent *) * size);
+        }
         for (int i = size; i < size + delta; i++)
             v[i] = nullptr;
         delete[] componentv;


### PR DESCRIPTION
Compiling & running with UBSan produces the following error:
```
csimulation.cc:319:19: runtime error: null pointer passed as argument 2, which is declared to never be null
```

`memcpy` is marked with `__nonull` for source & destination parameters in GNU libc, so passing `nullptr` is undefined behaviour. If the size of the elements to be copied is zero, this still does the right thing, so in case `componentv` is `nullptr`, which happens on the first call of `cSimulation::registerComponent`, this has no negative effect.

Checking if the source argument is a valid pointer alleviates this.