### PR TITLE
scave: fix each run in exported JSON file containing results of all runs

### DIFF
--- a/src/scave/jsonexporter.cc
+++ b/src/scave/jsonexporter.cc
@@ -304,6 +304,9 @@ void JsonExporter::saveResults(const std::string& fileName, ResultFileManager *m
             for (ID id : scalars) {
                 ScalarResult buffer;
                 const ScalarResult *scalar = manager->getScalar(id, buffer);
+                if (scalar->getRun() != run)
+                    continue;
+
                 writer.openObject();
                 writer.writeString("module", scalar->getModuleName());
                 writer.writeString("name", scalar->getName());
@@ -321,6 +324,9 @@ void JsonExporter::saveResults(const std::string& fileName, ResultFileManager *m
             writer.openArray("parameters");
             for (ID id : parameters) {
                 const ParameterResult *scalar = manager->getParameter(id);
+                if (scalar->getRun() != run)
+                    continue;
+
                 writer.openObject();
                 writer.writeString("module", scalar->getModuleName());
                 writer.writeString("name", scalar->getName());
@@ -338,6 +344,9 @@ void JsonExporter::saveResults(const std::string& fileName, ResultFileManager *m
             writer.openArray("statistics");
             for (ID id : statistics) {
                 const StatisticsResult *stats = manager->getStatistics(id);
+                if (stats->getRun() != run)
+                    continue;
+
                 writer.openObject();
                 writer.writeString("module", stats->getModuleName());
                 writer.writeString("name", stats->getName());
@@ -355,6 +364,9 @@ void JsonExporter::saveResults(const std::string& fileName, ResultFileManager *m
             writer.openArray("histograms");
             for (ID id : histograms) {
                 const HistogramResult *histogram = manager->getHistogram(id);
+                if (histogram->getRun() != run)
+                    continue;
+
                 writer.openObject();
                 writer.writeString("module", histogram->getModuleName());
                 writer.writeString("name", histogram->getName());
@@ -384,6 +396,9 @@ void JsonExporter::saveResults(const std::string& fileName, ResultFileManager *m
             for (int i = 0; i < (int)vectors.size(); i++) {
                 ID id = vectors.get(i);
                 const VectorResult *vector = manager->getVector(id);
+                if (vector->getRun() != run)
+                    continue;
+
                 writer.openObject();
                 writer.writeString("module", vector->getModuleName());
                 writer.writeString("name", vector->getName());


### PR DESCRIPTION
Hi,

When simulation results from multiple simulation runs are converted to JSON using `opp_scavetool`, each run in the resulting JSON file contains results of all runs. Therefore, when converting the result files of two runs, each of the two runs contains the scalars, vectors, etc. of both runs.

This pull request fixes the before mentioned behavior by checking the run when iterating over the results. A possible drawback of this fix might be that an empty scalars, vectors, etc. array will be created if a particular run does not contain results of a specific type while other runs do.

Best regards,
Daniel