### PR TITLE
Fix missing dollar signs in code example in HTML version of OMNeT++ simulation manual

### DIFF
--- a/doc/src/manual/ltoh
+++ b/doc/src/manual/ltoh
@@ -626,8 +626,10 @@ sub do_comment_verbatim {
         }
 
         # attempt math formatting. --Andras Varga
-        $line =~ s!\$\$([^\n]+?)\$\$!"<center>" . formatmath($1,0) . "</center>"!gse;
-        $line =~ s/\$([^\n]+?)\$/formatmath($1,1)/gse;
+        if ($inh == $false) {
+            $line =~ s!\$\$([^\n]+?)\$\$!"<center>" . formatmath($1,0) . "</center>"!gse;
+            $line =~ s/\$([^\n]+?)\$/formatmath($1,1)/gse;
+        }
 
         if ($skip == $true) {
             $line = "";


### PR DESCRIPTION
Hi,
In the code example in Section 19.4.13.2 "Inout Gates" of the OMNeT++ simulation manual, the dollar signs are missing in the HTML version, while they are present in the PDF version. When looking closely, it can also be seen that the text between the supposed positions of the dollar signs is italic. Looking at the HTML code confirms this, as an open and closing \<i\> tag is added instead of the dollar signs.

![Screenshot from 2021-07-14 11-17-31](https://user-images.githubusercontent.com/7644267/125619858-861bd99d-f6b8-44e4-a94f-4dab2e02afbe.png)

I was able to track down the problem to a misinterpretation of the two dollar signs as math mode delimiters by the used LaTeX to HTML (ltoh) converter.  As these are the only lines of code in the entire manual that contain more than one dollar sign per line, the problem is only present there, while all other dollar signs in the code examples are rendered correctly.

This pull request solves the problem by patching the LaTeX to HTML converter (ltoh) to ignore math formatting in code and htmlonly environments. The fixed code example and the change in the HTML code can be seen here:

![Screenshot from 2021-07-14 11-17-55](https://user-images.githubusercontent.com/7644267/125621314-f4aeead9-a621-49fd-85fc-a150ef438244.png)
![Screenshot from 2021-07-14 11-20-05](https://user-images.githubusercontent.com/7644267/125621335-359b6fcd-4ad2-4d6f-995a-81502a23e02d.png)

Best regards,
Daniel