### PR TITLE
Simulator core 2% performance boost - skip isTerminated() dynamic_cast unless necessary

### DIFF
--- a/include/omnetpp/csimplemodule.h
+++ b/include/omnetpp/csimplemodule.h
@@ -347,6 +347,10 @@ class SIM_API cSimpleModule : public cModule //implies noncopyable
      * or returning from the activity() method.
      */
     bool isTerminated() const {return flags&FL_ISTERMINATED;}
+    static bool isTerminated(cModule* mod){
+        return static_cast<cSimpleModule*>(mod)->isTerminated()
+                &&dynamic_cast<cSimpleModule*>(mod);
+    };
     //@}
 
     /** @name Debugging aids. */

--- a/src/sim/cmessage.cc
+++ b/src/sim/cmessage.cc
@@ -338,8 +338,8 @@ void cMessage::setSentFrom(cModule *module, int gateId, simtime_t_cref t)
 bool cMessage::isStale()
 {
     // check that destination module still exists and is alive
-    cSimpleModule *module = dynamic_cast<cSimpleModule *>(getSimulation()->getModule(targetModuleId));
-    return !module || module->isTerminated();
+    auto *module = getSimulation()->getModule(targetModuleId);
+    return !module || cSimpleModule::isTerminated(module);
 }
 
 #ifdef NDEBUG


### PR DESCRIPTION
On windows, approx 3% of execution time in a simulation I was running was spent in `cMessage::isStale()`.
Largely this is because of the dynamic cast. Since the `isTerminated()`
check is actually a trivial bit comparison it can be done before dynamic cast which is relatively slow. Then the dynamic cast is done
only if it evaluates as true.

## Profiling setup 
* 3.8GHz i7
* Windows 10
* OMNeT++ 5.6.2
* INET 4.2

run `inet/examples/manetrouting` with the following configuration
```
[Config TestRuntime]
extends= IPv4
repeat = 10
seed-set = 0
**.statistic-recording = false
sim-time-limit = 5000s
*.host[0].app[0].printPing = false
```

The execution time of each of the simulations ( in sec)  is below;

| No Change | Changed | Changed | No Change |
|-----------|---------|---------|-----------|
| 23.0      | 22.2    | 22.1    | 22.94     |
| 23.3      | 22.4    | 22.0    | 22.6      |
| 23.5      | 22.4    | 22.3    | 22.9      |
| 23.4      | 23.0    | 22.0    | 22.6      |
| 22.8      | 21.8    | 22.3    | 22.8      |
| 23.0      | 22.7    | 22.3    | 22.5      |
|           | 22.3    | 22.3    | 23.3      |
| 23.8      | 22.4    | 21.9    | 23.1      |
| 23.3      | 22.7    | 22.2    | 22.9      |
| 23.1      | 21.8    | 22.0    | 23.2      |

No change avg: 23.1

Changed code avg: 22.3

## Conclusion

The results from my profiling of this are as below which shows a clear 2% performance boost - Possibly more

The additional dynamic cast if the flag is true may not be required but I'm not sure.