### PR TITLE
Fix build: include <memory> for std:unique_ptr

### DIFF
--- a/src/common/expression.cc
+++ b/src/common/expression.cc
@@ -18,6 +18,7 @@
 #include <stack>
 #include <typeinfo>
 #include <cinttypes>
+#include <memory>
 #include "commonutil.h"
 #include "stlutil.h"
 #include "expression.h"

--- a/src/scave/opp_scavetool.cc
+++ b/src/scave/opp_scavetool.cc
@@ -16,6 +16,7 @@
 #include <iomanip>
 #include <map>
 #include <algorithm>
+#include <memory>
 #include "common/ver.h"
 #include "common/fileutil.h"
 #include "common/linetokenizer.h"

--- a/src/sim/cdynamicexpression.cc
+++ b/src/sim/cdynamicexpression.cc
@@ -13,6 +13,7 @@
   `license' for details on this and other legal matters.
 *--------------------------------------------------------------*/
 
+#include <memory>
 #include "common/expression.h"
 #include "common/exception.h"
 #include "common/unitconversion.h"

--- a/src/sim/nedsupport.cc
+++ b/src/sim/nedsupport.cc
@@ -13,6 +13,7 @@
   `license' for details on this and other legal matters.
 *--------------------------------------------------------------*/
 
+#include <memory>
 #include "common/stringutil.h"
 #include "common/exprutil.h"
 #include "omnetpp/cdynamicexpression.h"


### PR DESCRIPTION
Hi,

I failed to build omnetpp with clang 13.0.1:

```
expression.cc:137:10: error: no member named 'unique_ptr' in namespace 'std'
    std::unique_ptr<AstNode> astTree(parseToAst(expr));
```

`std:unique_ptr` is defined in `<memory>` but not included. This patch adds the includes for all relevant source files.

Best,
Christoph