### PR TITLE
Add uint64 support to string tokenizer. 

### DIFF
--- a/include/omnetpp/cstringtokenizer.h
+++ b/include/omnetpp/cstringtokenizer.h
@@ -18,6 +18,7 @@
 
 #include <string>
 #include <vector>
+#include <stdint.h>
 #include "simkerneldefs.h"
 
 namespace omnetpp {
@@ -155,6 +156,12 @@ class SIM_API cStringTokenizer
      * in a vector.
      */
     std::vector<int> asIntVector();
+
+    /**
+     * Utility function: converts all tokens to uint64_t, and returns them
+     * in a vector.
+     */
+    std::vector<uint64_t> asUint64Vector();
 
     /**
      * Utility function: converts all tokens to double, and returns them

--- a/src/sim/cstringtokenizer.cc
+++ b/src/sim/cstringtokenizer.cc
@@ -77,6 +77,24 @@ std::vector<std::string> cStringTokenizer::asVector()
     return vec;
 }
 
+std::vector<uint64_t> cStringTokenizer::asUint64Vector()
+{
+    const char *s;
+    std::vector<uint64_t> v;
+    while ((s = nextToken()) != nullptr) {
+        char *e;
+        errno = 0;
+
+        uint64_t d = strtoull(s, &e, 10);
+        if (*e)
+            throw cRuntimeError("Converting string to a vector of ints: Error at token '%s'", s);
+        if (errno == ERANGE)
+            throw cRuntimeError("Converting string to a vector of ints: '%s' does not fit into an int", s);
+        v.push_back(d);
+    }
+    return v;
+}
+
 std::vector<int> cStringTokenizer::asIntVector()
 {
     const char *s;


### PR DESCRIPTION
Add uint64 support to string tokenizer. Useful for lists of MAC addresses in configuration files.
