### PR TITLE
Fixed broken image in ch-build-sim-progs.tex

### DIFF
--- a/doc/src/manual/ch-build-sim-progs.tex
+++ b/doc/src/manual/ch-build-sim-progs.tex
@@ -58,7 +58,7 @@ building (and running) simulation programs.
 
 \begin{figure}[htbp]
   \begin{center}
-    \includesvg{figures/build-workflow}
+    \includesvg[width=\linewidth]{figures/build-workflow}
     \caption{Building and running simulation}
     \label{fig:ch-build:workflow}
   \end{center}


### PR DESCRIPTION
See page 270:
![image](https://github.com/omnetpp/omnetpp/assets/30051680/f9c506e9-a441-46d0-a2fc-2a688a4b3a69)
