### PR TITLE
Fix macOS compatibility issues

### DIFF
--- a/configure
+++ b/configure
@@ -2820,12 +2820,16 @@ case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
 
 
 # check command line arguments and override the values set in configure.user with them
-for arg in $ac_configure_args
+eval "set -- $ac_configure_args"
+for arg
 do
   stripped_arg=$(echo $arg | sed "s/^\('\)\(.*\)\1\$/\2/g")
   case $stripped_arg in
     -*  ) continue ;;
-    *=* ) eval $stripped_arg ;;
+    *=* )
+      key=${stripped_arg%%"="*}
+      value=${stripped_arg#*"="}
+      eval "$key=\"$value\"" ;;
   esac
 done
 

--- a/configure.in
+++ b/configure.in
@@ -162,12 +162,16 @@ AC_CONFIG_AUX_DIR(src/utils)
 AC_CANONICAL_HOST()
 
 # check command line arguments and override the values set in configure.user with them
-for arg in $ac_configure_args
+eval "set -- $ac_configure_args"
+for arg
 do
   stripped_arg=$(echo $arg | sed "s/^\([']\)\(.*\)\1\$/\2/g")
   case $stripped_arg in
     -*  ) continue ;;
-    *=* ) eval $stripped_arg ;;
+    *=* )
+      key=${stripped_arg%%"="*}
+      value=${stripped_arg#*"="}
+      eval "$key=\"$value\"" ;;
   esac
 done
 

--- a/include/omnetpp/cvalue.h
+++ b/include/omnetpp/cvalue.h
@@ -93,6 +93,8 @@ class SIM_API cValue
     cValue(bool b)  {set(b);}
     cValue(int l)  {set((intval_t)l);}
     cValue(int l, const char *unit)  {set((intval_t)l, unit);}
+    cValue(long l)  {set((intval_t)l);}
+    cValue(long l, const char *unit)  {set((intval_t)l, unit);}
     cValue(intval_t l)  {set(l);}
     cValue(intval_t l, const char *unit)  {set(l, unit);}
     cValue(double d)  {set(d);}


### PR DESCRIPTION
Currently, when building on a macOS host, there are two issues:

- The build environment usually requires exporting compiler and linker flags to include homebrew search paths. For some reason (possibly autoconf compatibility with broken terminals?), even when exported in a separate command prior, `ac_configure_args` picks them up as arguments to the configure script. Said script mishandles spaces and their quotation, causing errors when parsing `CFLAGS` and `LDFLAGS`.
- With the standard ABI, there is no definite cValue constructor for values of type long. Passing the result of `PyLong_AsLong` thus yields ambiguity errors.

Both issues are resolved trivially and should not cause regressions for other platforms.