### PR TITLE
Changed XYArray length and indicies type to size_t instead of int

### DIFF
--- a/src/scave/csvrecexporter.cc
+++ b/src/scave/csvrecexporter.cc
@@ -358,7 +358,7 @@ void CsvRecordsExporter::writeXAsString(const XYArray *data)
     std::ostream& out = csv.out();
     csv.beginRaw();
     out << "\"";
-    for (int j = 0; j < data->length(); j++) {
+    for (size_t j = 0; j < data->length(); j++) {
         if (j != 0)
             out << " ";
         if (data->hasPreciseX())
@@ -375,7 +375,7 @@ void CsvRecordsExporter::writeYAsString(const XYArray *data)
     std::ostream& out = csv.out();
     csv.beginRaw();
     out << "\"";
-    for (int j = 0; j < data->length(); j++) {
+    for (size_t j = 0; j < data->length(); j++) {
         if (j != 0)
             out << " ";
         csv.writeRawDouble(data->getY(j));

--- a/src/scave/csvspreadexporter.cc
+++ b/src/scave/csvspreadexporter.cc
@@ -310,7 +310,7 @@ void CsvForSpreadsheetExporter::saveVectors(ResultFileManager *manager, const ID
             csv.writeString(vector->getModuleName());
             csv.writeString(vector->getName());
             csv.writeString("TIME");
-            for (int j = 0; j < data->length(); j++) {
+            for (size_t j = 0; j < data->length(); j++) {
                 if (data->hasPreciseX())
                     csv.writeBigDecimal(data->getPreciseX(j));
                 else
@@ -323,7 +323,7 @@ void CsvForSpreadsheetExporter::saveVectors(ResultFileManager *manager, const ID
             csv.writeString(vector->getModuleName());
             csv.writeString(vector->getName());
             csv.writeString("VALUE");
-            for (int j = 0; j < data->length(); j++)
+            for (size_t j = 0; j < data->length(); j++)
                 csv.writeBigDecimal(data->getY(j));
             csv.writeNewLine();
         }
@@ -341,12 +341,12 @@ void CsvForSpreadsheetExporter::saveVectors(ResultFileManager *manager, const ID
         }
 
         // count number of data rows
-        int numRows = 0;
+        size_t numRows = 0;
         for (int i = 0; i < numVectors; ++i)
             numRows = std::max(numRows, xyArrays[i]->length());
 
         // write data rows
-        for (int i = 0; i < numRows; ++i) {
+        for (size_t i = 0; i < numRows; ++i) {
             for (int j = 0; j < numVectors; ++j) {
                 XYArray *data = xyArrays[j];
                 if (data->length() <= i) {

--- a/src/scave/jsonexporter.cc
+++ b/src/scave/jsonexporter.cc
@@ -186,9 +186,9 @@ void JsonExporter::writeX(XYArray *array)
     std::ostream& out = writer.out();
     writeVectorProlog();
     bool first = true;
-    int n = array->length();
+    size_t n = array->length();
     bool hasPreciseX = array->hasPreciseX();
-    for (int i = 0; i < n; i++) {
+    for (size_t i = 0; i < n; i++) {
         if (!first)
             out << ", ";
         first = false;
@@ -207,8 +207,8 @@ void JsonExporter::writeY(XYArray *array)
     std::ostream& out = writer.out();
     writeVectorProlog();
     bool first = true;
-    int n = array->length();
-    for (int i = 0; i < n; i++) {
+    size_t n = array->length();
+    for (size_t i = 0; i < n; i++) {
         if (!first)
             out << ", ";
         first = false;
@@ -224,8 +224,8 @@ void JsonExporter::writeEventNumbers(XYArray *array)
     std::ostream& out = writer.out();
     writeVectorProlog();
     bool first = true;
-    int n = array->length();
-    for (int i = 0; i < n; i++) {
+    size_t n = array->length();
+    for (size_t i = 0; i < n; i++) {
         if (!first)
             out << ", ";
         first = false;

--- a/src/scave/omnetppvectorfileexporter.cc
+++ b/src/scave/omnetppvectorfileexporter.cc
@@ -149,9 +149,9 @@ void OmnetppVectorFileExporter::saveResults(const std::string& fileName, ResultF
             const VectorResult *vector = manager->getVector(id);
             void *vectorHandle = vectorHandles[i];
             XYArray *array = xyArrays[i];
-            int length = array->length();
+            size_t length = array->length();
             bool hasPreciseX = array->hasPreciseX();
-            for (int j = 0; j < length; j++) {
+            for (size_t j = 0; j < length; j++) {
                 const BigDecimal time = hasPreciseX ? array->getPreciseX(j) : BigDecimal(array->getX(j));
                 if (!time.isSpecial())
                     writer.recordInVector(vectorHandle, array->getEventNumber(j), time.getIntValue(), time.getScale(), array->getY(j));

--- a/src/scave/python/scave_bindings.cc
+++ b/src/scave/python/scave_bindings.cc
@@ -264,7 +264,7 @@ NB_MODULE(MODULENAME, m) {
             nb::ndarray<double, nb::ndim<1>, nb::c_contig, nb::device::cpu> xs,
             nb::ndarray<double, nb::ndim<1>, nb::c_contig, nb::device::cpu> ys
         ) {
-            int l = xyArray->length();
+            size_t l = xyArray->length();
             if (xs.shape(0) != l || ys.shape(0) != l)
                 throw std::runtime_error("xyArrayToNumpyArrays: shape mismatch");
             memcpy(xs.data(), xyArray->xs.data(), l * sizeof(double));

--- a/src/scave/sqlitevectorfileexporter.cc
+++ b/src/scave/sqlitevectorfileexporter.cc
@@ -145,9 +145,9 @@ void SqliteVectorFileExporter::saveResults(const std::string& fileName, ResultFi
             const VectorResult *vector = manager->getVector(id);
             void *vectorHandle = vectorHandles[i];
             XYArray *array = xyArrays[i];
-            int length = array->length();
+            size_t length = array->length();
             bool hasPreciseX = array->hasPreciseX();
-            for (int j = 0; j < length; j++) {
+            for (size_t j = 0; j < length; j++) {
                 const BigDecimal time = hasPreciseX ? array->getPreciseX(j) : BigDecimal(array->getX(j));
                 if (!time.isSpecial())
                     writer.recordInVector(vectorHandle, array->getEventNumber(j), time.getMantissaForScale(simtimeScaleExp), array->getY(j));

--- a/src/scave/xyarray.h
+++ b/src/scave/xyarray.h
@@ -40,12 +40,12 @@ class SCAVE_API XYArray
 
         bool hasPreciseX() const  {return !xps.empty();}
         bool hasEventNumbers() const  {return !ens.empty();}
-        int length() const  {return xs.size();}
+        size_t length() const  {return xs.size();}
 
-        double getX(int i) const  {return xs.at(i);}
-        double getY(int i) const  {return ys.at(i);}
-        const BigDecimal& getPreciseX(int i) const {return xps.at(i); }
-        eventnumber_t getEventNumber(int i) const {return ens.at(i); }
+        double getX(size_t i) const  {return xs.at(i);}
+        double getY(size_t i) const  {return ys.at(i);}
+        const BigDecimal& getPreciseX(size_t i) const {return xps.at(i); }
+        eventnumber_t getEventNumber(size_t i) const {return ens.at(i); }
 };
 
 }  // namespace scave

--- a/test/misc/scave/vectorfilereadertest.cc
+++ b/test/misc/scave/vectorfilereadertest.cc
@@ -110,8 +110,8 @@ void testReaderBuilder(const char *inputfile, const char *outputfile)
         const VectorResult& vector = resultfilemanager.getVector(id);
         ArrayBuilderNode *builder = builders[i];
         XYArray *array = builder->getArray();
-        int s = array->length();
-        for (int i = 0; i < s; ++i) {
+        size_t s = array->length();
+        for (size_t i = 0; i < s; ++i) {
             BigDecimal xp = array->getPreciseX(i);
             double x = array->getX(i);
             double y = array->getY(i);

--- a/ui/org.omnetpp.common.core/src/org/omnetpp/common/color/ColorFactory.java
+++ b/ui/org.omnetpp.common.core/src/org/omnetpp/common/color/ColorFactory.java
@@ -853,7 +853,7 @@ public class ColorFactory {
     /**
      * Returns a "good" light color.
      */
-    public static Color getGoodLightColor(int i) {
+    public static Color getGoodLightColor(long i) {
         return goodLightColors[i % goodLightColors.length];
     }
 

--- a/ui/org.omnetpp.common.core/src/org/omnetpp/common/color/ColorFactory.java
+++ b/ui/org.omnetpp.common.core/src/org/omnetpp/common/color/ColorFactory.java
@@ -854,7 +854,7 @@ public class ColorFactory {
      * Returns a "good" light color.
      */
     public static Color getGoodLightColor(long i) {
-        return goodLightColors[i % goodLightColors.length];
+        return goodLightColors[(int) (i % goodLightColors.length)];
     }
 
     public static Color[] getGoodDarkColors() {

--- a/ui/org.omnetpp.sequencechart/src/org/omnetpp/sequencechart/widgets/axisrenderer/AxisVectorBarRenderer.java
+++ b/ui/org.omnetpp.sequencechart/src/org/omnetpp/sequencechart/widgets/axisrenderer/AxisVectorBarRenderer.java
@@ -96,13 +96,13 @@ public class AxisVectorBarRenderer implements IAxisRenderer {
     public void drawAxis(Graphics graphics, IEvent startEvent, IEvent endEvent)
     {
         Rectangle rect = graphics.getClip(Rectangle.SINGLETON);
-        int size = getDataLength();
+        long size = getDataLength();
 
-        int startIndex = getIndex(startEvent, true);
+        long startIndex = getIndex(startEvent, true);
         if (startIndex == -1)
             startIndex = 0;
 
-        int endIndex = getIndex(endEvent, false);
+        long endIndex = getIndex(endEvent, false);
         if (endIndex == -1)
             endIndex = size;
 
@@ -119,7 +119,7 @@ public class AxisVectorBarRenderer implements IAxisRenderer {
         // draw axis as a colored thick line with labels representing values
         // two phases: first draw the background and after that draw the values
         for (int phase = 0; phase < 2; phase++) {
-            for (int i = startIndex; i < endIndex; i++) {
+            for (long i = startIndex; i < endIndex; i++) {
                 long eventNumber = getEventNumber(i);
                 long nextEventNumber = Math.min(endEventNumber, (i == size - 1) ? endEventNumber : getEventNumber(i + 1));
 
@@ -162,7 +162,7 @@ public class AxisVectorBarRenderer implements IAxisRenderer {
                 if (x1 == Integer.MAX_VALUE || x2 == Integer.MAX_VALUE)
                     continue;
 
-                int colorIndex = getValueIndex(i);
+                long colorIndex = getValueIndex(i);
                 graphics.setBackgroundColor(ColorFactory.getGoodLightColor(colorIndex));
 
                 if (phase == 0) {
@@ -200,15 +200,15 @@ public class AxisVectorBarRenderer implements IAxisRenderer {
     /**
      * Returns the element index having less or greater or equal event number in the data array depending on the given flag.
      */
-    public int getIndex(IEvent event, boolean before)
+    public long getIndex(IEvent event, boolean before)
     {
-        int index = -1;
-        int left = 0;
-        int right = getDataLength() - 1;
+        long index = -1;
+        long left = 0;
+        long right = getDataLength() - 1;
         long eventNumber = event.getEventNumber();
 
         while (left <= right) {
-            int mid = (right + left) / 2;
+            long mid = (right + left) / 2;
 
             if (getEventNumber(mid) == eventNumber) {
                 do {
@@ -254,14 +254,14 @@ public class AxisVectorBarRenderer implements IAxisRenderer {
     /**
      * Returns the index having less or greater or equal simulation time in the data array depending on the given flag.
      */
-    public int getIndex(BigDecimal simulationTime, boolean before)
+    public long getIndex(BigDecimal simulationTime, boolean before)
     {
-        int index = -1;
-        int left = 0;
-        int right = getDataLength();
+        long index = -1;
+        long left = 0;
+        long right = getDataLength();
 
         while (left <= right) {
-            int mid = (right + left) / 2;
+            long mid = (right + left) / 2;
 
             if (getSimulationTime(mid) == simulationTime) {
                 do {
@@ -302,17 +302,17 @@ public class AxisVectorBarRenderer implements IAxisRenderer {
         }
     }
 
-    public int getDataLength()
+    public long getDataLength()
     {
         return data.length();
     }
 
-    public BigDecimal getSimulationTime(int index)
+    public BigDecimal getSimulationTime(long index)
     {
         return new BigDecimal(data.getPreciseX(index).toBigDecimal());
     }
 
-    public long getEventNumber(int index)
+    public long getEventNumber(long index)
     {
         Assert.isTrue(0 <= index && index < data.length());
         data.getX(index);
@@ -321,12 +321,12 @@ public class AxisVectorBarRenderer implements IAxisRenderer {
         return data.getEventNumber(index);
     }
 
-    public double getValue(int index)
+    public double getValue(long index)
     {
         return data.getY(index);
     }
 
-    private int getValueIndex(int index)
+    private long getValueIndex(long index)
     {
         if (type == ResultItem.DataType.TYPE_ENUM || type == ResultItem.DataType.TYPE_INT)
             return (int)Math.floor(getValue(index));
@@ -339,7 +339,7 @@ public class AxisVectorBarRenderer implements IAxisRenderer {
         }
     }
 
-    private String getValueText(int index)
+    private String getValueText(long index)
     {
         if (type == ResultItem.DataType.TYPE_ENUM)
             return enumType.nameOf((int)Math.floor(getValue(index)));


### PR DESCRIPTION
The current implementation of the `xyarray` uses `int` for indexing and getting the length of its internal vectors. This caused issues when working with very large vectors. Replaced `int` with `size_t` in `xyarray` and its references to support large vectors and make size handling platform-independent.