### PR TITLE
opp_makemake: detect Windows without relying on the OS variable

### DIFF
--- a/src/utils/opp_makemake
+++ b/src/utils/opp_makemake
@@ -96,7 +96,8 @@ def makemake():
     if args.is_deep:
         args.recurse = False
 
-    is_windows = bool(os.environ.get('OS')) and 'windows' in os.environ['OS'].lower()
+    # the OS variable is unset in some MSYS2 shells, do not rely on it
+    is_windows = os.name == 'nt' or sys.platform in ('win32', 'cygwin', 'msys')
 
     makecommand = os.environ.get("MAKE") or "make"
 


### PR DESCRIPTION
Closes #1506. Supersedes #1508, which was opened against the stale `master` branch by mistake.

The long linker line workaround was disabled whenever the OS environment variable is unset, which is the case in the MSYS2 shell shipped with OMNeT++ on Windows. `is_windows` was therefore false on Windows and `gcclongline` was silently turned off, so linking failed on projects with long object lists.

Detection now uses `os.name` and `sys.platform`. The `OS` check was dropped rather than kept as a fallback, since `os.name == 'nt'` already covers native and MinGW Python and `sys.platform` covers MSYS and Cygwin.

Verified with the Python bundled with OMNeT++ 6.3.0 on Windows:

    OS set     old: True   new: True    unchanged
    OS unset   old: False  new: True    the reported bug
    posix      old: False  new: False   no change on Linux and macOS

The second hunk is not part of the fix: the file does not end with a newline, and the GitHub web editor added one. Happy to drop it if you prefer.